### PR TITLE
Allow global redirect to follow specific ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,14 @@ const blacklist = require('./blacklist');
 
 mailUtilities = bluebird.promisifyAll(mailUtilities);
 
-const invalidTXTError = new Error('Host configuration error: Invalid TXT record.');
+const invalidTXTError = new Error(
+  'Host configuration error: Invalid TXT record.'
+);
 invalidTXTError.responseCode = 550;
 
-const invalidMXError = new Error('Your domain has outdated MX records, please contact your host.');
+const invalidMXError = new Error(
+  'Your domain has outdated MX records, please contact your host.'
+);
 invalidMXError.responseCode = 550;
 
 const invalidUserError = new Error('Mailbox not found. Check your spelling?');
@@ -595,7 +599,8 @@ class ForwardEmail {
         // record = "forward-email=niftylettuce@gmail.com"
         // e.g. hello@niftylettuce.com => niftylettuce@gmail.com
         //      *@niftylettuce.com => hellolettuce@gmail.com
-        // record = "forward-email=hello:niftylettuce@gmail.com,hellolettuce@gmail.com"
+        // record = "forward-email=
+        //      hello:niftylettuce@gmail.com,hellolettuce@gmail.com"
         record = record.replace('forward-email=', '');
 
         // remove trailing whitespaces from each address listed
@@ -606,37 +611,43 @@ class ForwardEmail {
         // store if we have a forwarding address or not
         let forwardingAddress;
 
-          // get username from recipient email address
-          // (e.g. hello@niftylettuce.com => hello)
-          const username = this.parseUsername(address);
+        // get username from recipient email address
+        // (e.g. hello@niftylettuce.com => hello)
+        const username = this.parseUsername(address);
 
-          for (let i = 0; i < addresses.length; i++) {
-            const address = addresses[i].split(':');
+        for (let i = 0; i < addresses.length; i++) {
+          const address = addresses[i].split(':');
 
-          // if we don't have a forwarding address then use this as a global redirect /  "catch-all"
-          // don't waste time checking additional entries, the docs say that it should be the last
+          // if we don't have a forwarding address then use this as a
+          // global redirect /  "catch-all"; don't waste time checking
+          // additional entries, the docs say that it should be the last
           // entry and that everything else is ignored
-            if (address.length === 1) {
-	            	forwardingAddress = address[0]; 
-                break;
-	          } else if (address.length > 2) throw invalidTXTError; 
+          if (address.length === 1) {
+            forwardingAddress = address[0];
+            break;
+          } else if (address.length > 2) throw invalidTXTError;
 
-            // address[0] = hello (username)
-            // address[1] = niftylettuce@gmail.com (forwarding email)
+          // address[0] = hello (username)
+          // address[1] = niftylettuce@gmail.com (forwarding email)
 
-            // check if we have a match
-            if (username === address[0]) {
-              forwardingAddress = address[1];
-              break;
-            }
+          // check if we have a match
+          if (username === address[0]) {
+            forwardingAddress = address[1];
+            break;
           }
+        }
 
         // if we don't have a forwarding address then throw an error
         if (!forwardingAddress) throw invalidTXTError;
-        
-        // fixme check if this is done somewhere else... 
-        if (!(validator.isFQDN(this.parseDomain(forwardingAddress)) &&
-              validator.isEmail(forwardingAddress))) throw invalidTXTError;
+
+        // fixme check if this is done somewhere else...
+        if (
+          !(
+            validator.isFQDN(this.parseDomain(forwardingAddress)) &&
+            validator.isEmail(forwardingAddress)
+          )
+        )
+          throw invalidTXTError;
 
         // otherwise transform the + symbol filter if we had it
         // and then resolve with the newly formatted forwarding address

--- a/index.js
+++ b/index.js
@@ -29,11 +29,14 @@ const blacklist = require('./blacklist');
 
 mailUtilities = bluebird.promisifyAll(mailUtilities);
 
-const invalidTXTError = new Error('Invalid forward-email TXT record');
+const invalidTXTError = new Error('Invalid email TXT record.');
 invalidTXTError.responseCode = 550;
 
-const invalidMXError = new Error('Sender has invalid MX records');
+const invalidMXError = new Error('Your domain has invalid MX records, please contact your host.');
 invalidMXError.responseCode = 550;
+
+const invalidUserError = new Error('Mailbox not found. Check your spelling?');
+invalidUserError.responseCode = 551;
 
 const headers = [
   'subject',

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,7 @@ test('rejects forwarding a non-registered email address', async t => {
     connection.connect(() => {
       connection.send(info.envelope, info.message, err => {
         t.is(err.responseCode, 550);
-        t.regex(err.message, /Invalid forward-email TXT record/);
+        t.regex(err.message, /Host configuration error: Invalid TXT record./);
         connection.quit();
       });
     });


### PR DESCRIPTION
Also more user-friendly tweaks to the error messages.

Eg. not having a specific user in redirect list would give the sender an "Invalid forward-email TXT record." - this case has been changed to "Mailbox not found."

Also, sender having invalid MX records is more likely to be because they're outdated and need updating... 