### PR TITLE
add support for IDN usernames

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,9 +115,12 @@ class ForwardEmail {
 
   parseUsername(address) {
     ({ address } = addressParser(address)[0]);
-    return address.indexOf('+') === -1
+    username = address.indexOf('+') === -1
       ? address.split('@')[0]
       : address.split('+')[0];
+    
+    username = punycode.toASCII(username);
+    return username;
   }
 
   parseFilter(address) {


### PR DESCRIPTION
ForwardEmail already supports IDN domain names and they work quite nicely and I use them a lot.

However, it currently does not support IDN usernames which are also allowed. I think a simple conversion from unicode to punycode should solve this problem. (and then putting the punycode in the DNS TXT record).