### PR TITLE
Accept configuration instead of hard-coded

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@
 * [CLI](#cli)
 * [API](#api)
 * [Usage](#usage)
+
   * [CLI](#cli-1)
   * [API](#api-1)
 * [Service-Level Agreement](#service-level-agreement)
 * [Terms of Use](#terms-of-use)
 * [FAQ](#faq)
+
   * [Why did I create this service](#why-did-i-create-this-service)
   * [Can people unregister or register my email forwarding without my permission](#can-people-unregister-or-register-my-email-forwarding-without-my-permission)
   * [How is it free](#how-is-it-free)
@@ -110,7 +112,7 @@ After you've followed the steps above in [How It Works](#how-it-works) you can f
    * Select `Other` under the drop-down for `Select device`
    * When prompted for text input, enter your custom domain's email address you're forwarding from (e.g. `hello@niftylettuce.com` - this will help you keep track in case you use this service for multiple accounts)
 3. Copy the password to your clipboard that is automatically generated
-    > :warning: If you are using Google Apps, visit your admin panel [Apps > G Suite >Settings for Gmail > Advanced settings](https://admin.google.com//AdminHome#ServiceSettings/service=email&subtab=filters) and make sure to check "Allow users to send mail through an external SMTP server...". There will be some delay for this change to be activated, so please wait for ~5-10 minutes.
+   > :warning: If you are using Google Apps, visit your admin panel [Apps > G Suite >Settings for Gmail > Advanced settings](https://admin.google.com//AdminHome#ServiceSettings/service=email&subtab=filters) and make sure to check "Allow users to send mail through an external SMTP server...". There will be some delay for this change to be activated, so please wait for ~5-10 minutes.
 4. Go to [Gmail](https://gmail.com) and under [Settings > Accounts and Import > Send mail as](https://mail.google.com/mail/u/0/#settings/accounts), click `Add another email address`
 5. When prompted for `Name`, enter the name that you want your email to be seen as "From" (e.g. `Niftylettuce`)
 6. When prompted for `Email address`, enter the email address with the custom domain you used above (e.g. `hello@niftylettuce.com`)
@@ -276,7 +278,18 @@ Use PM2 in combination with an `ecosystem.json` file and `authbind` (see the exa
 ```js
 const ForwardEmail = require('forward-email');
 
-const forwardEmail = new ForwardEmail();
+const forwardEmail = new ForwardEmail({
+    exchanges: ['mx1.forwardemail.net', 'mx2.forwardemail.net'],
+    ssl: {
+      key: '/home/deploy/mx1.forwardemail.net.key',
+      cert: '/home/deploy/mx1.forwardemail.net.cert',
+      ca: '/home/deploy/mx1.forwardemail.net.ca'
+    },
+    dkim: {
+      domainName: 'forwardemail.net',
+      privateKey: '/home/deploy/dkim-private.key'
+    }
+  });
 
 forwardEmail.listen();
 ```

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -5,6 +5,10 @@
       "script": "index.js",
       "exec_mode": "cluster",
       "instances": "max",
+      "env": {
+        "SECURE": "false",
+        "PORT": "25"
+      },
       "env_production": {
         "NODE_ENV": "production"
       }
@@ -14,10 +18,12 @@
       "script": "index.js",
       "exec_mode": "cluster",
       "instances": "max",
-      "env_production": {
-        "NODE_ENV": "production",
+      "env": {
         "SECURE": "true",
         "PORT": "465"
+      },
+      "env_production": {
+        "NODE_ENV": "production"
       }
     },
     {
@@ -25,10 +31,12 @@
       "script": "index.js",
       "exec_mode": "cluster",
       "instances": "max",
-      "env_production": {
-        "NODE_ENV": "production",
+      "env": {
         "SECURE": "true",
         "PORT": "587"
+      },
+      "env_production": {
+        "NODE_ENV": "production"
       }
     }
   ],

--- a/index.js
+++ b/index.js
@@ -325,10 +325,11 @@ class ForwardEmail {
               // verify transport
               // await transporter.verify();
 
-              const dkim = {};
-              dkim.domainName = this.config.dkim.domainName;
-              dkim.keySelector = 'default';
-              dkim.privateKey = fs.readFileSync(this.config.dkim.privateKey, 'utf8');
+              const dkim = {
+                domainName: this.config.dkim.domainName,
+                keySelector: 'default',
+                privateKey: fs.readFileSync(this.config.dkim.privateKey, 'utf8')
+              };
 
               const email = {
                 ...obj,
@@ -675,9 +676,10 @@ if (!module.parent) {
     },
     dkim: {
       domainName: 'forwardemail.net',
-      privateKey: process.env.NODE_ENV === 'production'
-        ? '/home/deploy/dkim-private.key'
-        : path.join(__dirname, 'dkim-private.key')
+      privateKey:
+        process.env.NODE_ENV === 'production'
+          ? '/home/deploy/dkim-private.key'
+          : path.join(__dirname, 'dkim-private.key')
     }
   });
   forwardEmail.server.listen(process.env.PORT || 25);

--- a/index.js
+++ b/index.js
@@ -91,8 +91,10 @@ class ForwardEmail {
     };
 
     // setup rate limiting with redis
+    if (!('db' in this.config.limiter)) {
+      this.config.limiter.db = redis.createClient();
+    }
     this.limiter = {
-      db: redis.createClient(),
       max: 100, // max requests within duration
       duration: ms('1h'),
       ...this.config.limiter

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint-staged": "latest",
     "nyc": "latest",
     "prettier": "latest",
+    "redis-mock": "^0.37.0",
     "remark-cli": "latest",
     "remark-preset-github": "latest",
     "shelljs": "^0.8.2",

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,5 +1,5 @@
 const getPort = require('get-port');
-const redis = require('redis');
+const redis = require('redis-mock');
 
 const ForwardEmail = require('../..');
 
@@ -16,7 +16,9 @@ const beforeEach = t => {
       });
     }),
     (async () => {
-      const forwardEmail = new ForwardEmail();
+      const forwardEmail = new ForwardEmail({
+        limiter: { db: client }
+      });
       const port = await getPort();
       forwardEmail.server = forwardEmail.server.listen(port, () => {
         t.context.forwardEmail = forwardEmail;

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ const nodemailer = require('nodemailer');
 const Client = require('nodemailer/lib/smtp-connection');
 const domains = require('disposable-email-domains');
 const { oneLine } = require('common-tags');
+const redis = require('redis-mock');
 
 const ForwardEmail = require('..');
 const { beforeEach, afterEach } = require('./helpers');
@@ -20,7 +21,10 @@ test.beforeEach(beforeEach);
 test.afterEach(afterEach);
 
 test('returns itself', t => {
-  t.true(new ForwardEmail() instanceof ForwardEmail);
+  const forwardEmail = new ForwardEmail({
+    limiter: { db: redis.createClient() }
+  });
+  t.true(forwardEmail instanceof ForwardEmail);
 });
 
 test('binds context', t => {


### PR DESCRIPTION
Excellent project, excellent service. I would like to host my own instance and the hard-coded configuration make it difficult and unmaintainable. What about passing the service configuration as default and allow to run it's own instance with it's own configuration? I think a better patch for this could be done, but the moment this will help to someone trying to setup their self-hosted service.