### PR TITLE
Forward to multiple addresses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "no-console": "off"
+    }
+};


### PR DESCRIPTION
- Add support for multiple forwarding addresses.
- Adds a config option for max forwarding addresses for a single input address (defaults to 10).
- Adds a check that the forwarded address is not itself forwarded, to prevent cascading forwarding.

Fixes #24 

@niftylettuce I would appreciate some feedback on this. The tests don't pass yet, but I think that's due to my local not being configured properly to run them (no spamassasin, DKIM keys, etc).