### PR TITLE
docs: add note about dmarc when using gmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@
 _Optional Add-ons:_
 
 * Add a DMARC record for your domain name by following the instructions at <https://dmarc.postmarkapp.com> (this will allow DMARC verification to pass)
+> :warning: If you intend to use [Send Mail As using Gmail](#send-mail-as-using-gmail), you can only set the DMARC policy to `p=none` – e.g. `v=DMARC1; p=none; pct=100; rua=mailto:re+random-key@dmarc.postmarkapp.com;`. Setting other policies, `quarantine` or `reject`, may cause sent mails to end up in recipient's spam folder or not delivered at all.
+>
+> DMARC requires both `From` and `Return-Path` to match the same domain. When you use "Send Mail As", your Gmail address would be used as the `Return-Path`, instead of your custom domain in `From`.
+
 * If the email lands in your spam folder (which it should not), you can whitelist it (e.g. here are instructions for Google <https://support.google.com/a/answer/60751?hl=en&ref_topic=1685627>)
 * Add the ability to "Send Mail As" from Gmail by following [Send Mail As Using Gmail](#send-mail-as-using-gmail) below
 
@@ -539,7 +543,7 @@ At no point in time do we write to disk or store emails – everything is done i
 [MIT](LICENSE) © [Nick Baugh](http://niftylettuce.com/)
 
 
-## 
+##
 
 [npm]: https://www.npmjs.com/
 


### PR DESCRIPTION
I recently tried `p=quarantine` policy. Email sent using custom domain via Gmail ended up in recipient's (Outlook) spam. Subsequent check on the header,
```
Authentication-Results: spf=pass (sender IP is [google-ip])
smtp.mailfrom=gmail.com; outlook.com; dkim=none (message not signed)
header.d=none;outlook.com; dmarc=fail action=quarantine header.from=custom.domain;compauth=fail reason=001
```
 and web searches ([[1]](https://postmarkapp.com/support/article/1088-dmarc-reporting-tool-faq), [[2]](https://dmarcian.com/how-can-spfdkim-pass-and-yet-dmarc-fail/)), showed Gmail use my Gmail address as `Return-Path`, which is different from `From` which is my custom domain; different domain=DMARC fail.