### PR TITLE
Use TXT Record for SPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@
 
 | Name/Host/Alias    |  TTL | Record Type | Value/Answer/Destination                        |
 | ------------------ | :--: | ----------- | ----------------------------------------------- |
-| _@ or leave blank_ | 3600 | SPF         | `v=spf1 a mx include:spf.forwardemail.net -all` |
+| _@ or leave blank_ | 3600 | TXT         | `v=spf1 a mx include:spf.forwardemail.net -all` |
 
 > :warning: If you are using Google Apps, you'll need to append `include:_spf.google.com` to the value above – e.g. `v=spf1 a mx include:spf.forwardemail.net include:_spf.google.com -all`.
 >


### PR DESCRIPTION
https://help.dnsmadeeasy.com/managed-dns/dns-record-types/txt-record/
https://mxtoolbox.com/problem/spf/spf-record-deprecated
https://www.socketlabs.com/blog/best-practices-sender-policy-framework-spf/