### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@
 
 **3.** Set (and customize) the following SPF record for SPF verification for your domain name (this will allow SPF verification to pass, note that you may need to enclose this value in quotes if you are using Amazon Route53):
 
-> Note that if you are using a service such as GoDaddy, you will need to use a TXT record type instead of an SPF record for this step.
->
 > If you're using a service like AWS Route 53, then edit your existing TXT record and add the following as a new line:
 
 | Name/Host/Alias    |  TTL | Record Type | Value/Answer/Destination                        |


### PR DESCRIPTION
Removed "Note that if you are using a service such as GoDaddy, you will need to use a TXT record type instead of an SPF record for this step." since the document recommends a TXT record now :)