### PR TITLE
Added Encrypted option using JSON Web Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Forward Email
 
-[![build status](https://semaphoreci.com/api/v1/niftylettuce/forward-email/branches/master/shields_badge.svg)](https://semaphoreci.com/niftylettuce/forward-email)
 [![code coverage](https://img.shields.io/codecov/c/github/niftylettuce/forward-email.svg)](https://codecov.io/gh/niftylettuce/forward-email)
 [![code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dkim": "^0.4.1",
     "email-providers": "^0.30.0",
     "get-port": "^3.2.0",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.10",
     "mailin": "^3.0.4",
     "mailparser": "^2.2.0",


### PR DESCRIPTION
Added an option to use secret email addresses in the repository. 
Also, the open version of the TXT records will break.

So, people who have no problem with their public address being public can use as it is.
And people who want to hide their forwarding address can use the following TXT record;

**forward-email-hashed=TOKEN_GENERATED**

_If we agree to use this JWT token, I will also write to the script to generate tokens as well_